### PR TITLE
Newsroom updates and broken link fix

### DIFF
--- a/web/federalsustainabilityplan/fed-supplier-rule.html
+++ b/web/federalsustainabilityplan/fed-supplier-rule.html
@@ -190,7 +190,6 @@
             <h2>Currently Available GHG Emission and Risk Resources</h2>
             <h3>Inventorying GHG Emissions</h3>
             <p><a href="https://ghgprotocol.org/corporate-standard">GHG Protocol Corporate Accounting and Reporting Standard</a>: Developed by the World Resources Institute and the World Business Council for Sustainable Development, this is the global standard for calculating corporate GHG emissions. The Standard includes guidance for preparing a GHG emissions inventory for Scope 1, Scope 2, and relevant categories of Scope 3 emissions.</p>
-            <p><a href="https://ghgprotocol.org/ghg-emissions-calculation-tool">The GHG Emissions Calculation Tool</a>: This Excel-based tool offered by the Greenhouse Gas Protocol can be used to calculate Scope 1, Scope 2, and Scope 3 emissions in line with the GHG Protocol.</p>
             <h3>Assessing Climate Risks</h3>
             <p><a href="https://assets.bbhub.io/company/sites/60/2021/10/FINAL-2017-TCFD-Report.pdf">Task Force on Climate-Related Financial Disclosures (TCFD) Recommendations</a>: The TCFD recommendations outline the core elements of climate-related financial disclosures across governance, strategy, risk management, and metrics and targets, as well as guidance on how to implement them.</p>
             <h3>Setting Emissions Reduction Targets</h3>

--- a/web/index.html
+++ b/web/index.html
@@ -225,7 +225,11 @@ $(window).load(function() {
         <div class="two_third">
           <div class="news-col">
             <h3>News from the CSO</h3>
-              <div class="news-item">
+               <div class="news-item">
+              <h4><a href="https://www.gsa.gov/about-us/newsroom/news-releases/gsa-pilots-buy-clean-inflation-reduction-act-requirements-for-low-embodied-carbon-construction-materials-05162023">GSA Pilots Buy Clean Inflation Reduction Act Requirements for Low Embodied Carbon Construction Materials</a></h4>
+				      <p>May 16, 2023</p>
+            </div>
+			  <div class="news-item">
               <h4><a href="https://www.gsa.gov/about-us/newsroom/news-releases/gsa-administrator-cuts-ribbon-on-gridinteractive-and-smart-building-technologies-at-oklahoma-city-federal-building-05112023">GSA Administrator Cuts Ribbon On Grid-Interactive and Smart Building Technologies at Oklahoma City Federal Building</a></h4>
 				      <p>May 11, 2023</p>
             </div>
@@ -233,10 +237,7 @@ $(window).load(function() {
               <h4><a href="https://www.gsa.gov/about-us/newsroom/news-releases/gsa-administrator-announces-over-$40-million-to-boost-building-efficiency-and-create-jobs-in-texas-and-louisiana-05102023">GSA Administrator Announces Over $40 Million to Boost Building Efficiency and Create Jobs in Texas and Louisiana</a></h4>
 				      <p>May 10, 2023</p>
             </div>
-			  <div class="news-item">
-              <h4><a href="https://www.gsa.gov/about-us/newsroom/news-releases/gsas-energy-retrofit-program-issues-largest-ever-call-to-accelerate-progress-toward-net-zero-buildings-through-president-bidens-investing-in-america-agenda-05102023">GSA's Energy Retrofit Program Issues Largest Ever Call to Accelerate Progress Toward Net Zero Buildings through President Biden's Investing in America Agenda</a></h4>
-				      <p>May 10, 2023</p>
-            </div>
+			 
             <p class="more"><a href="newsroom.html">Read more news releases</a>.</p>
           </div>
         </div>

--- a/web/newsroom.html
+++ b/web/newsroom.html
@@ -136,6 +136,10 @@
 			<div class="content_fullwidth">
 				<div class="one_full news">
             <div class="news-item">
+              <h2><a href="https://www.gsa.gov/about-us/newsroom/news-releases/gsa-pilots-buy-clean-inflation-reduction-act-requirements-for-low-embodied-carbon-construction-materials-05162023">GSA Pilots Buy Clean Inflation Reduction Act Requirements for Low Embodied Carbon Construction Materials</a></h2>
+				      <p>May 16, 2023</p>
+            </div>
+			<div class="news-item">
               <h2><a href="https://www.gsa.gov/about-us/newsroom/news-releases/gsa-administrator-cuts-ribbon-on-gridinteractive-and-smart-building-technologies-at-oklahoma-city-federal-building-05112023">GSA Administrator Cuts Ribbon On Grid-Interactive and Smart Building Technologies at Oklahoma City Federal Building</a></h2>
 				      <p>May 11, 2023</p>
             </div>
@@ -164,6 +168,10 @@
 				      <p>April 18, 2023</p>
             </div>
           <div class="news-item">
+            <h2><a href="https://www.whitehouse.gov/briefing-room/statements-releases/2023/04/17/fact-sheet-biden-harris-administration-announces-new-private-and-public-sector-investments-for-affordable-electric-vehicles/">FACT SHEET: Biden-⁠Harris Administration Announces New Private and Public Sector Investments for Affordable Electric Vehicles</a></h2>
+            <p>April 17, 2023</p>
+          </div>
+		  <div class="news-item">
             <h2><a href="https://www.gsa.gov/about-us/newsroom/news-releases/gsa-and-dhs-formalize-partnership-to-promote-sustainability-04172023">GSA and DHS Formalize Partnership to Promote Sustainability</a></h2>
             <p>April 17, 2023</p>
           </div>


### PR DESCRIPTION
Two newsroom stories added and GHG Emissions Calculation Tool removed (tool isn't available).